### PR TITLE
VSX can return 'noSuchInstance' for 'R0X25C 6410 v2 Chassis'.

### DIFF
--- a/check_arubaoscx_health
+++ b/check_arubaoscx_health
@@ -282,13 +282,9 @@ package AOS;
 			return 0;
 		}
 
-		if ($self->{vsxDeviceRole}{"arubaWiredVsxDeviceRole.0"}{value}{value} =~ /noSuchObject/) {
+		if ($self->{vsxDeviceRole}{"arubaWiredVsxDeviceRole.0"}{value}{value} =~ /(noSuchObject|noSuchInstance|notConfigured)/) {
 			return 0;
 		}
-		if ($self->{vsxDeviceRole}{"arubaWiredVsxDeviceRole.0"}{value}{string} =~ /notConfigured/) {
-			return 0;
-		}
-
 		return 1;
 	}
 

--- a/check_arubaoscx_health
+++ b/check_arubaoscx_health
@@ -348,7 +348,7 @@ package AOS;
 		}
 
 		my @status=map { $_->{arubaWiredPSUName}{value} . " " . $_->{arubaWiredPSUState}{value} } @nonok;
-		return sprintf("%s %s", join(",", @status));
+		return sprintf("%s", join(",", @status));
 	}
 
 	sub psu_ok {


### PR DESCRIPTION
Your script works with my 6410 after this change. VSX is not enabled on my box.

Instead of adding a new condition, I merged the condition by modifying the regex.